### PR TITLE
Update README.md to clarify usages of data_sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The script installs several demo data sets, each with an associated variable nam
 If you want to install only specific subsets of data, use the following command with the appropriate data set options (e.g., `sample`, `custom`, `security`, `o11y`, or `makelogs`):
 
 ```bash
-curl -sSL https://elastic.github.io/kibana-demo-data | sh -s [data_set]
+curl -sSL https://elastic.github.io/kibana-demo-data | sh -s <data_set>
 ```
 
 For example, to install **Kibana Sample Data** and **Custom Sample Data** together, run:


### PR DESCRIPTION
Update the missleading 

curl -sSL https://elastic.github.io/kibana-demo-data | sh -s [data_set]

Leading people astray, it could be an array they could use 

It's not an array, it can be one or more data_sets, delimited with `space`